### PR TITLE
feat : Add detail view for displaying individual ads

### DIFF
--- a/sales/models.py
+++ b/sales/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from ordered_model.models import OrderedModel
+from django.urls import reverse
 
 class CustomUser(AbstractUser):
     """
@@ -51,6 +52,9 @@ class Ad(models.Model):
 
     def is_visible_to_user(self, user):
         return self.contact_info_visible or user == self.user
+
+    def get_absolute_url(self):
+        return reverse('ad_detail', args=[str(self.pk)])
     
 class AdImage(OrderedModel):
     """

--- a/sales/templates/ad_detail_view.html
+++ b/sales/templates/ad_detail_view.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="ad-title-row">
+        <h1 class="ad-title">{{ ad.title }}</h1>
+
+        {% if show_user_contact_info and user_phone_number %}
+            <div class="user-contact-box">
+                <div class="user-contact-inline">
+                    <div class="user-contact-label">
+                        <i class="bi bi-telephone"></i> Seller Contact
+                    </div>
+                    <div class="user-contact-number">
+                        {{ user_phone_number }}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
+
+    <div class="ad-detail-container">
+        <p><strong>Category:</strong> {{ ad.category.name }}</p>
+        <p><strong>Description:</strong> {{ ad.description }}</p>
+
+        <p><strong>Price:</strong>
+            {% if ad.price %}
+                ${{ ad.price }}
+            {% else %}
+                N/A
+            {% endif %}
+        </p>
+
+        <p><strong>Location:</strong> {{ ad.location }}</p>
+        <p><strong>Posted by:</strong> {{ ad.user.username }} on {{ ad.created_at|date:"F d, Y" }}</p>
+
+        {% if ad.event_date %}
+            <p><strong>Event Date:</strong> {{ ad.event_date|date:"F d, Y" }}</p>
+        {% endif %}
+
+        {% if show_contact_info %}
+            <p><strong>Contact Info:</strong> {{ ad.contact_info }}</p>
+        {% else %}
+            <p><em>Ad contact information is hidden.</em></p>
+        {% endif %}
+
+        {% if images %}
+            <div class="ad-image-gallery">
+                {% for image in images %}
+                    <img src="{{ image.image.url }}" alt="{{ ad.title }}" class="ad-image">
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/sales/templates/base.html
+++ b/sales/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SalesVenue</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
 </head>
 <body class="d-flex flex-column min-vh-100">

--- a/sales/tests/test_ad_detail_view.py
+++ b/sales/tests/test_ad_detail_view.py
@@ -1,0 +1,94 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from sales.models import Ad, AdImage, Category
+from datetime import date
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+class AdDetailViewTest(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.client = Client()
+
+        # Create user and ad owner
+        self.user = User.objects.create_user(username='testuser', password='password')
+        self.ad_owner = User.objects.create_user(username='owner', password='password', first_name='OwnerName')
+        self.ad_owner.phone_number = '1234567890'
+        self.ad_owner.contact_info_visibility = True
+        self.ad_owner.save()
+
+        # Create category
+        self.category = Category.objects.create(name='Electronics')
+
+        # Create an active ad
+        self.ad = Ad.objects.create(
+            title='Test Ad',
+            description='Test Description',
+            price=100,
+            location='Test City',
+            user=self.ad_owner,
+            is_active=True,
+            category=self.category,
+            created_at=date.today(),
+            event_date=date(2025, 9, 1),
+            contact_info='owner@example.com'
+        )
+
+        self.image = AdImage.objects.create(ad=self.ad, image=SimpleUploadedFile(name='test_image.jpg', content=b'', content_type='image/jpeg'))
+        self.detail_url = reverse('ad_detail', kwargs={'pk': self.ad.pk})
+
+    def test_ad_detail_view_renders_active_ad(self):
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.ad.title)
+
+    def test_only_active_ads_are_accessible(self):
+        self.ad.is_active = False
+        self.ad.save()
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_context_includes_contact_info_visibility(self):
+        self.client.login(username='testuser', password='password')
+        response = self.client.get(self.detail_url)
+        self.assertIn('show_contact_info', response.context)
+        self.assertIn('show_user_contact_info', response.context)
+
+    def test_user_contact_info_shown_when_visible(self):
+        self.client.login(username='testuser', password='password')
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, 'Seller Contact')
+        self.assertContains(response, '1234567890')
+
+    def test_user_contact_info_hidden_when_not_visible(self):
+        self.ad_owner.contact_info_visibility = False
+        self.ad_owner.save()
+        self.client.login(username='testuser', password='password')
+        response = self.client.get(self.detail_url)
+        self.assertNotContains(response, 'Seller Contact')
+        self.assertNotContains(response, '1234567890')
+
+    def test_images_are_included_in_context(self):
+        response = self.client.get(self.detail_url)
+        self.assertIn('images', response.context)
+        self.assertEqual(list(response.context['images']), list(self.ad.images.all()))
+        self.assertContains(response, self.image.image.url)
+
+    def test_template_used(self):
+        response = self.client.get(self.detail_url)
+        self.assertTemplateUsed(response, 'ad_detail_view.html')
+
+    def test_event_date_displayed(self):
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, self.ad.event_date.strftime('%B %d, %Y'))
+
+    def test_ad_owner_username_displayed(self):
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, self.ad_owner.username)
+
+    def test_contact_info_hidden_if_not_visible_to_user(self):
+        self.ad.contact_info_visibility = False
+        self.ad.save()
+        self.client.login(username='testuser', password='password')
+        response = self.client.get(self.detail_url)
+        self.assertContains(response, 'Ad contact information is hidden.')

--- a/sales/urls.py
+++ b/sales/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import AdListView
+from .views import AdListView, AdDetailView
 
 urlpatterns = [
     path('', AdListView.as_view(), name='ad_list'),
+    path('ads/<int:pk>/', AdDetailView.as_view(), name='ad_detail'),
 ]

--- a/sales/views.py
+++ b/sales/views.py
@@ -1,5 +1,5 @@
-from django.shortcuts import render
-from django.views.generic import ListView
+from django.shortcuts import render, get_object_or_404
+from django.views.generic import ListView, DetailView
 from .models import Ad
 
 class AdListView(ListView):
@@ -13,3 +13,24 @@ class AdListView(ListView):
         return Ad.objects.filter(is_active=True).select_related('user', 'category') \
                                                 .prefetch_related('images') \
                                                 .order_by('-created_at')
+
+class AdDetailView(DetailView):
+    model = Ad
+    template_name = 'ad_detail_view.html'
+    context_object_name = 'ad'
+
+    def get_queryset(self):
+        return Ad.objects.filter(is_active=True).select_related('user').prefetch_related('images')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        ad = self.object
+        user = self.request.user
+        context['show_contact_info'] = ad.is_visible_to_user(user)
+        
+        ad_owner = ad.user
+        context['show_user_contact_info'] = ad_owner.contact_info_visibility
+        context['user_phone_number'] = ad_owner.phone_number if ad_owner.contact_info_visibility else None
+        context['images'] = ad.images.all()
+
+        return context


### PR DESCRIPTION
### Summary
This PR introduces the `AdDetailView`, which allows users to view detailed information for a specific advertisement. It uses Django's `DetailView` to fetch and display a single ad based on its primary key (pk).

### Changes Made
- Added `AdDetailView` in `views.py`
- Created `ad_detail.html` template for rendering the ad details
- Updated `urls.py` to include the route for the detail view
- Applied Bootstrap classes for clean layout and responsiveness