### PR TITLE
feat : Add unread message notification to Dashboard conversation list

### DIFF
--- a/sales/models.py
+++ b/sales/models.py
@@ -108,6 +108,9 @@ class Conversation(models.Model):
             self.owner = self.ad.user
         super().save(*args, **kwargs)
 
+    def has_unread_for(self, user):
+        return self.messages.filter(read=False).exclude(sender=user).exists()
+
 class Message(models.Model):
     """
     Represents a private message sent between two users regarding a specific ad.

--- a/sales/templates/conversations/list.html
+++ b/sales/templates/conversations/list.html
@@ -4,6 +4,9 @@
     <li>
         <a href="{% url 'conversation_detail' conv.pk %}">
             {{ conv.ad.title }} — Other: {{ conv.other_username }} — {{ conv.created_at|date:"M d, Y H:i" }}
+            {% if conv.has_unread %}
+                <span class="text-danger fw-bold">(Have unread)</span>
+            {% endif %}
         </a>
     </li>
     {% empty %}

--- a/sales/templates/conversations/scripts/conversations_script.html
+++ b/sales/templates/conversations/scripts/conversations_script.html
@@ -13,20 +13,19 @@
   }
   
   function appendMessage(m) {
-    const div = document.createElement('div');
-    div.className = 'message ' + (m.sender_id == {{ request.user.id }} ? 'me' : 'them');
-    div.dataset.id = m.id;
-    div.dataset.sentAt = m.sent_at;
+  const div = document.createElement('div');
+  div.className = 'message ' + (m.sender_id == {{ request.user.id }} ? 'me' : 'them');
+  div.dataset.id = m.id;
+  div.dataset.sentAt = m.sent_at;
 
-    const header = document.createElement('small');
-    const strong = document.createElement('strong');
-    strong.textContent = m.sender;
-
-    const em = document.createElement('em');
-    em.textContent = ' ' + (new Date(m.sent_at)).toLocaleString();
-
-    header.appendChild(strong);
-    header.appendChild(em);
+  // header
+  const header = document.createElement('small');
+  const strong = document.createElement('strong');
+  strong.textContent = m.sender;
+  const em = document.createElement('em');
+  em.textContent = ' ' + (new Date(m.sent_at)).toLocaleString();
+  header.appendChild(strong);
+  header.appendChild(em);
 
     const body = document.createElement('div');
     body.classList.add('message-content');

--- a/sales/templates/conversations/scripts/conversations_script.html
+++ b/sales/templates/conversations/scripts/conversations_script.html
@@ -62,10 +62,11 @@ body.appendChild(document.createTextNode(line));
 }
 
 
-  async function poll() {
+  // In your script tag, replace the old poll function with this one
+async function poll() {
     let url = `{% url 'conversation_messages_json' conversation.pk %}`;
     if (lastTimestamp) {
-      url += '?after=' + encodeURIComponent(lastTimestamp);
+        url += '?after=' + encodeURIComponent(lastTimestamp);
     }
     try {
       const resp = await fetch(url, {credentials: 'same-origin'});

--- a/sales/views.py
+++ b/sales/views.py
@@ -168,6 +168,12 @@ class ConversationDetailView(LoginRequiredMixin, DetailView):
         conversation = self.get_object()
         if request.user not in (conversation.owner, conversation.buyer):
             return HttpResponseForbidden("You don't have access to this conversation.")
+
+        Message.objects.filter(
+            conversation=conversation,
+            read=False
+        ).exclude(sender=request.user).update(read=True)
+
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -177,7 +183,6 @@ class ConversationDetailView(LoginRequiredMixin, DetailView):
         context['form'] = MessageForm()
         context["other_user"] = conversation.other_user(self.request.user)
         return context
-
 
 class SendMessageView(LoginRequiredMixin, View):
     def post(self, request, conversation_id, *args, **kwargs):
@@ -360,6 +365,9 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         user = self.get_user()
         conversations = self._get_user_conversations(user)
+
+        for conv in conversations:
+            conv.has_unread = conv.has_unread_for(user)
 
         context["user_obj"] = user
         context["conversations"] = conversations


### PR DESCRIPTION
---
This PR enhances the Dashboard’s conversation list by adding a visible “(Have unread)” badge next to any conversation containing unread messages for the logged-in user.
---

- Updated DashboardView to set a has_unread attribute for each conversation using has_unread_for(user).

- Updated conversation list template to display the “(Have unread)” badge when has_unread is True.