### PR TITLE
refactor: Add Image Slideshow to Ad Detail View

### DIFF
--- a/sales/templates/ad_detail_view.html
+++ b/sales/templates/ad_detail_view.html
@@ -54,11 +54,38 @@
         {% endif %}
 
         {% if images %}
-            <div class="ad-image-gallery">
+        <div id="adImageCarousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="4000">
+            
+            <div class="carousel-indicators">
                 {% for image in images %}
-                    <img src="{{ image.image.url }}" alt="{{ ad.title }}" class="ad-image">
+                    <button type="button" data-bs-target="#adImageCarousel" 
+                            data-bs-slide-to="{{ forloop.counter0 }}" 
+                            {% if forloop.first %}class="active"{% endif %} 
+                            aria-current="true" 
+                            aria-label="Slide {{ forloop.counter }}">
+                    </button>
                 {% endfor %}
             </div>
+
+            <div class="carousel-inner">
+                {% for image in images %}
+                    <div class="carousel-item {% if forloop.first %}active{% endif %}">
+                        <img src="{{ image.image.url }}" class="d-block w-100 ad-image" alt="{{ ad.title }}">
+                    </div>
+                {% endfor %}
+            </div>
+
+            <button class="carousel-control-prev" type="button" data-bs-target="#adImageCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+            </button>
+
+            <button class="carousel-control-next" type="button" data-bs-target="#adImageCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Next</span>
+            </button>
+        </div>
         {% endif %}
+
     </div>
 {% endblock %}


### PR DESCRIPTION
This feature enhances the Ad detail page by introducing an image slideshow for ads with multiple images, improving the way users browse and interact with media.

---

- Provides a richer and more engaging user experience when viewing ads.
- Makes it easy to navigate through multiple images without clutter.
- Improves visual presentation and highlights ads more effectively.
- Mobile-friendly and responsive for different screen sizes.