### PR TITLE
feat: Make Conversation List View for Switching Between All Conversations and Only Unread

### DIFF
--- a/sales/templates/ad_form.html
+++ b/sales/templates/ad_form.html
@@ -13,7 +13,7 @@
 
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        
+
         <fieldset class="mb-4 p-3 border rounded">
             <legend class="float-none w-auto px-1">Ad Details</legend>
             {% for field in form %}

--- a/sales/templates/ad_form.html
+++ b/sales/templates/ad_form.html
@@ -13,7 +13,7 @@
 
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
-
+        
         <fieldset class="mb-4 p-3 border rounded">
             <legend class="float-none w-auto px-1">Ad Details</legend>
             {% for field in form %}

--- a/sales/templates/conversations/list.html
+++ b/sales/templates/conversations/list.html
@@ -1,18 +1,32 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>Your Conversations</h2>
+
+<div class="mb-3">
+    <a href="{% url 'conversation_list' %}" 
+       class="btn {% if not request.GET.filter %}btn-primary{% else %}btn-outline-primary{% endif %}">
+       All
+    </a>
+    <a href="{% url 'conversation_list' %}?filter=unread" 
+       class="btn {% if request.GET.filter == 'unread' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+       Unread
+    </a>
+</div>
+
 <ul>
   {% for conv in conversations %}
     <li>
         <a href="{% url 'conversation_detail' conv.pk %}">
             {{ conv.ad.title }} — Other: {{ conv.other_username }} — {{ conv.created_at|date:"M d, Y H:i" }}
-            {% if conv.has_unread %}
-                <span class="text-danger fw-bold">(Have unread)</span>
+            {% if request.GET.filter == 'unread' %}
+                <span class="badge bg-danger ms-2">Unread</span>
             {% endif %}
         </a>
     </li>
-    {% empty %}
-        <li>No conversations yet.</li>
-    {% endfor %}
+  {% empty %}
+        <li>No conversations found.</li>
+  {% endfor %}
 </ul>
+
+
 {% endblock %}

--- a/sales/templates/conversations/list.html
+++ b/sales/templates/conversations/list.html
@@ -1,3 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
 <h2>Your Conversations</h2>
 <ul>
   {% for conv in conversations %}
@@ -13,3 +15,4 @@
         <li>No conversations yet.</li>
     {% endfor %}
 </ul>
+{% endblock %}

--- a/sales/templates/dashboard.html
+++ b/sales/templates/dashboard.html
@@ -29,7 +29,7 @@
         </div>
     </div>
     <a href="{% url 'conversation_list' %}" class="btn btn-outline-primary">
-        View All Unread Conversations
+        Conversations Page --->>>
     </a>
 </div>
 {% endblock %}

--- a/sales/templates/dashboard.html
+++ b/sales/templates/dashboard.html
@@ -28,9 +28,8 @@
             </div>
         </div>
     </div>
-
-    <div>
-        {% include "conversations/list.html" %}
-    </div>
+    <a href="{% url 'conversation_list' %}" class="btn btn-outline-primary">
+        View All Unread Conversations
+    </a>
 </div>
 {% endblock %}


### PR DESCRIPTION
This update enhances the Conversation List View by introducing a toggle that lets users switch between viewing all conversations or only those with unread messages.

---

- Gives users more control over how they view conversations.
- Makes it easier to quickly find unread conversations without losing access to the full history.
- Provides a cleaner and more efficient workflow for managing messages.
- Improves usability, especially for active users with many conversations.