### PR TITLE
feat: Enable Timezone based time display option using custom middleware

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -19,6 +19,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'timezone_field',
     'accounts',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -33,6 +34,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    "sales.middlewares.BrowserTimezoneMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -97,7 +99,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Asia/Kolkata'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 

--- a/sales/middlewares.py
+++ b/sales/middlewares.py
@@ -1,0 +1,17 @@
+from backports.zoneinfo import ZoneInfo
+from django.utils import timezone
+
+class BrowserTimezoneMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        tzname = request.COOKIES.get("timezone")
+        if tzname:
+            try:
+                timezone.activate(ZoneInfo(tzname))
+            except Exception:
+                timezone.deactivate()
+        else:
+            timezone.deactivate()
+        return self.get_response(request)

--- a/sales/templates/ad_detail_view.html
+++ b/sales/templates/ad_detail_view.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 {% block content %}
     <div class="ad-title-row">
         <h1 class="ad-title">{{ ad.title }}</h1>
@@ -30,7 +31,8 @@
         </p>
 
         <p><strong>Location:</strong> {{ ad.location }}</p>
-        <p><strong>Posted by:</strong> {{ ad.user.username }} on {{ ad.created_at|date:"F d, Y" }}</p>
+        <p><strong>Posted by:</strong> {{ ad.user.username }} on {{ ad.created_at|localtime|date:"F d, Y H:i" }}</p>
+        <p><strong>Updated on:</strong> {{ ad.updated_at| localtime |date:"F d, Y H:i" }}</p>
 
         {% if ad.event_date %}
             <p><strong>Event Date:</strong> {{ ad.event_date|date:"F d, Y" }}</p>

--- a/sales/templates/base.html
+++ b/sales/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load tz %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,6 +9,9 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <script>
+        document.cookie = "timezone=" + Intl.DateTimeFormat().resolvedOptions().timeZone + "; path=/";
+    </script>
 </head>
 <body class="d-flex flex-column min-vh-100">
     <header class="main-header">

--- a/sales/templates/conversations/ad_conversations.html
+++ b/sales/templates/conversations/ad_conversations.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block content %}
 <div class="container mt-4">
@@ -12,7 +13,7 @@
                         <h5 class="mb-1">{{ convo.buyer.username }}</h5>
                         <small class="text-muted">
                             {% if convo.messages.last %}
-                                {{ convo.messages.last.sent_at|date:"M d, Y H:i" }}
+                                {{ convo.messages.last.sent_at|localtime|date:"M d, Y H:i" }}
                             {% endif %}
                         </small>
                     </div>


### PR DESCRIPTION
-This PR introduces a custom middleware that automatically adjusts time display based on the user’s configured timezone.
-Previously, all times were displayed in the server’s default timezone, which caused confusion for users across different regions. With this middleware, each user now sees times localized to their own timezone, improving clarity and user experience.