### PR TITLE
feat: Enable Timezone based time display option using custom middleware

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -39,6 +39,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "sales.middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = 'myproject.urls'
@@ -54,6 +55,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                "sales.context_processors.timezone_form",
             ],
         },
     },
@@ -97,7 +99,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'Asia/Kolkata'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 

--- a/sales/context_processors.py
+++ b/sales/context_processors.py
@@ -1,0 +1,10 @@
+from .forms import TimezoneForm
+from django.utils.timezone import now
+
+def timezone_form(request):
+    context = {}
+    if request.user.is_authenticated:
+        context["timezone_form"] = TimezoneForm(instance=request.user)
+    # always add the current time
+    context["now"] = now()
+    return context

--- a/sales/forms.py
+++ b/sales/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.forms import inlineformset_factory
-from .models import Ad, AdImage, Message, Category
+from .models import Ad, AdImage, Message, Category, CustomUser
+from django.utils import timezone
+import pytz
 
 class AdForm(forms.ModelForm):
     class Meta:
@@ -35,3 +37,13 @@ class MessageForm(forms.ModelForm):
     class Meta:
         model = Message
         fields = ['content']
+
+class TimezoneForm(forms.ModelForm):
+    class Meta:
+        model = CustomUser
+        fields = ["timezone"]
+
+    timezone = forms.ChoiceField(
+        choices=[(tz, tz) for tz in pytz.common_timezones],
+        widget=forms.Select
+    )

--- a/sales/middleware.py
+++ b/sales/middleware.py
@@ -1,0 +1,12 @@
+from django.utils import timezone
+
+class TimezoneMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.user.is_authenticated and hasattr(request.user, "timezone"):
+            timezone.activate(request.user.timezone)
+        else:
+            timezone.deactivate()
+        return self.get_response(request)

--- a/sales/models.py
+++ b/sales/models.py
@@ -14,6 +14,7 @@ class CustomUser(AbstractUser):
     contact_info_visibility = models.BooleanField(default=False, help_text="Whether the user's contact information is visible")
     phone_number = models.CharField(max_length=15, blank=True, null=True, help_text="The user's contact phone number.")
     profile_picture = models.ImageField(upload_to='profile_pictures/', blank=True, null=True, help_text="A profile picture for the user.")
+    timezone = models.CharField(max_length=50, default="UTC")
 
     def __str__(self):
         return self.username

--- a/sales/templates/ad_detail_view.html
+++ b/sales/templates/ad_detail_view.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 {% block content %}
     <div class="ad-title-row">
         <h1 class="ad-title">{{ ad.title }}</h1>
@@ -30,7 +31,8 @@
         </p>
 
         <p><strong>Location:</strong> {{ ad.location }}</p>
-        <p><strong>Posted by:</strong> {{ ad.user.username }} on {{ ad.created_at|date:"F d, Y" }}</p>
+        <p><strong>Posted by:</strong> {{ ad.user.username }} on {{ ad.created_at|localtime|date:"F d, Y H:i" }}</p>
+        <p><strong>Updated on:</strong>{{ ad.updated_at|localtime|date:"F d, Y H:i" }}</p>
 
         {% if ad.event_date %}
             <p><strong>Event Date:</strong> {{ ad.event_date|date:"F d, Y" }}</p>

--- a/sales/templates/ad_list_view.html
+++ b/sales/templates/ad_list_view.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %} 
 {% load static %}
 {% block content %}
 
@@ -50,6 +51,9 @@
 </form>
 
     <h1 class="page-title">Ads For You</h1>
+    <p>UTC now: {{ now }}</p>
+<p>Localized now: {{ now|localtime }}</p>
+<p>User timezone: {{ user.timezone }}</p>
 
 <div class="mb-4">
     <a href="{% url 'ad_create' %}" class="btn btn-primary">+ Create New Ad</a>

--- a/sales/templates/ad_list_view.html
+++ b/sales/templates/ad_list_view.html
@@ -51,9 +51,6 @@
 </form>
 
     <h1 class="page-title">Ads For You</h1>
-    <p>UTC now: {{ now }}</p>
-<p>Localized now: {{ now|localtime }}</p>
-<p>User timezone: {{ user.timezone }}</p>
 
 <div class="mb-4">
     <a href="{% url 'ad_create' %}" class="btn btn-primary">+ Create New Ad</a>

--- a/sales/templates/base.html
+++ b/sales/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load tz %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -16,6 +17,16 @@
                 <h1 class="mb-0"><a href="{% url 'ad_list' %}" class="site-title">SalesVenue</a></h1>
                 <div class="d-flex align-items-center">
                     {% if user.is_authenticated %}
+                    <form method="post" action="{% url 'set_timezone' %}" class="d-flex align-items-center me-3">
+                        {% csrf_token %}
+                        <select name="timezone" class="form-select form-select-sm" style="width: auto;" onchange="this.form.submit()">
+                            {% for value, label in timezone_form.fields.timezone.choices %}
+                                <option value="{{ value }}" {% if timezone_form.instance.timezone == value %}selected{% endif %}>
+                                    {{ label }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </form>
                         <span class="welcome-text">Welcome, {{ user.username }}</span>
                         <a href="{% url 'dashboard' %}" class="btn btn-outline-light ms-3">
                             Dashboard

--- a/sales/templates/conversations/ad_conversations.html
+++ b/sales/templates/conversations/ad_conversations.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 
 {% block content %}
 <div class="container mt-4">
@@ -12,7 +13,7 @@
                         <h5 class="mb-1">{{ convo.buyer.username }}</h5>
                         <small class="text-muted">
                             {% if convo.messages.last %}
-                                {{ convo.messages.last.sent_at|date:"M d, Y H:i" }}
+                                {{ convo.messages.last.sent_at|localtime|date:"M d, Y H:i" }}
                             {% endif %}
                         </small>
                     </div>

--- a/sales/urls.py
+++ b/sales/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
-from .views import AdListView, AdDetailView, AdCreateView, AdUpdateView, AdDeleteView, DashboardView
+from .views import AdListView, AdDetailView, AdCreateView, AdUpdateView, AdDeleteView, DashboardView, set_timezone
+from . import views 
 
 urlpatterns = [
     path('', AdListView.as_view(), name='ad_list'),
@@ -8,4 +9,5 @@ urlpatterns = [
     path('ad/<int:ad_id>/update/', AdUpdateView.as_view(), name='ad_update'),
     path('ad/<int:ad_id>/delete/', AdDeleteView.as_view(), name='ad_delete'),
     path('dashboard/', DashboardView.as_view(), name='dashboard'),
+    path("set-timezone/", views.set_timezone, name="set_timezone"),
 ]

--- a/sales/views.py
+++ b/sales/views.py
@@ -4,7 +4,7 @@ from .models import Ad, Conversation, Message, Category
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
 from django.contrib import messages
-from .forms import AdForm, AdImageFormSet, MessageForm
+from .forms import AdForm, AdImageFormSet, MessageForm, TimezoneForm
 from .mixins import AdOwnerRequiredMixin
 from django.http import JsonResponse, HttpResponseForbidden
 from django.utils import timezone
@@ -15,6 +15,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django_filters.views import FilterView
 from .filters import AdFilter
+from django.contrib.auth.decorators import login_required
 
 class AdListView(FilterView):
     model = Ad
@@ -411,3 +412,12 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             )
             .order_by("-created_at")
         )
+
+@login_required
+def set_timezone(request):
+    if request.method == "POST":
+        form = TimezoneForm(request.POST, instance=request.user)
+        if form.is_valid():
+            form.save()
+    # Redirect back to the same page the user was on
+    return redirect(request.META.get("HTTP_REFERER", "home"))


### PR DESCRIPTION
-This PR introduces a custom middleware that automatically adjusts time display based on the user’s selected timezone across requests.
-Previously, all times were displayed in the server’s default timezone, which caused confusion for users across different regions. With this middleware, each user now sees times localized to their own selected timezone, improving clarity and user experience.